### PR TITLE
refactor: change the origin point of coordinate system conversion to the position of the camera for view port space

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -21,42 +21,12 @@ function step(timestamp: number){
     board.context.fillStyle = 'white';
     board.context.fillRect(-5000, -5000, 10000, 10000);
     
-    // drawXAxis(board.context, board.camera.zoomLevel);
-    // drawYAxis(board.context, board.camera.zoomLevel);
+    drawXAxis(board.context, board.camera.zoomLevel);
+    drawYAxis(board.context, board.camera.zoomLevel);
     board.context.lineWidth = 1 / board.camera.zoomLevel;
-    drawLine(board.context, {x: 0, y: 0}, {x: 1000, y: 0}, "rgb(160, 35, 52)");
-    drawLine(board.context, {x: 0, y: 0}, {x: 0, y: 1000}, "rgb(13, 124, 102)");
 
-    for(let i = 1; i < 20; i++){
-        drawLine(board.context, {x: i / 2, y: 0}, {x: i / 2, y: 0.25}, "black");
-        board.context.font = `${20 / board.camera.zoomLevel}px Arial`;
-        board.context.fillStyle = `rgba(0, 0, 0, ${1}`;
-        const textDimension = board.context.measureText(`${i}`);
-        const textCenter = PointCal.addVector({x: i / 2, y: 0.35}, {x: -textDimension.width / 2, y: textDimension.fontBoundingBoxAscent - textDimension.fontBoundingBoxDescent});
-        board.context.fillText(`${i}`, textCenter.x, textCenter.y);
-    }
-
-    for(let i = 1; i < 20; i++){
-        drawLine(board.context, {x: 0, y: i / 2}, {x: 0.25, y: i / 2}, "black");
-        board.context.font = `${20 / board.camera.zoomLevel}px Arial`;
-        board.context.fillStyle = `rgba(0, 0, 0, ${1}`;
-        const textDimension = board.context.measureText(`${i}`);
-        const textCenter = PointCal.addVector({x: 0.35, y: i / 2}, {x: -textDimension.width / 2, y: (textDimension.fontBoundingBoxAscent - textDimension.fontBoundingBoxDescent) / 2});
-        board.context.fillText(`${i}`, textCenter.x, textCenter.y);
-    }
-    
-    // drawArrow(board.context, {x: 0, y: 0}, {x: 1, y: 1}, board.camera.zoomLevel, "blue");
-    board.context.beginPath();
-    board.context.fillStyle = `rgba(0, 0, 0, ${1}`;
-    board.context.arc(0.5, 0.5, 2 / board.camera.zoomLevel, 0, 2 * Math.PI);
-    board.context.fill();
-    board.context.font = `${20 / board.camera.zoomLevel}px Arial`;
-    board.context.fillStyle = `rgba(0, 0, 0, ${1}`;
-    const textDimension = board.context.measureText("(1, 1)");
-    const textCenter = PointCal.addVector({x: 0.5, y: 0.5}, {x: +textDimension.width / 2, y: textDimension.fontBoundingBoxAscent - textDimension.fontBoundingBoxDescent});
-    board.context.fillText("(1, 1)", textCenter.x, textCenter.y);
-    const fourCorners = calculateTopFourCorners();
-    drawRuler(board.context, fourCorners.topLeft, fourCorners.topRight, fourCorners.bottomLeft, fourCorners.bottomRight, true, board.camera.zoomLevel);
+    // const fourCorners = calculateTopFourCorners();
+    // drawRuler(board.context, fourCorners.topLeft, fourCorners.topRight, fourCorners.bottomLeft, fourCorners.bottomRight, true, board.camera.zoomLevel);
 
     requestAnimationFrame(step);
 }
@@ -70,3 +40,9 @@ function calculateTopFourCorners(){
     const bottomRight = board.camera.convertFromViewPort2WorldSpace({x: board.camera.viewPortWidth, y: board.camera.viewPortHeight});
     return {topLeft, topRight, bottomLeft, bottomRight};
 }
+
+canvas.addEventListener('pointerdown', (event)=>{
+    const pointInWindow = {x: event.clientX, y: event.clientY};
+    const pointInWorld = board.convertWindowPoint2WorldCoord({x: pointInWindow.x, y: pointInWindow.y});
+    console.log('point in world space: ', pointInWorld);
+});

--- a/src/board-camera/board-camera-v2.ts
+++ b/src/board-camera/board-camera-v2.ts
@@ -4,7 +4,7 @@ import { CameraObserverV2, UnSubscribe } from 'src/camera-observer';
 import { withinBoundaries } from 'src/board-camera/utils/position';
 import { zoomLevelWithinLimits, ZoomLevelLimits, clampZoomLevel } from 'src/board-camera/utils/zoom';
 import { RotationLimits, rotationWithinLimits, normalizeAngleZero2TwoPI, clampRotation } from 'src/board-camera/utils/rotation';
-import { convert2WorldSpace } from 'src/board-camera/utils/coordinate-conversion';
+import { convert2WorldSpaceAnchorAtCenter, convert2ViewPortSpaceAnchorAtCenter } from 'src/board-camera/utils/coordinate-conversion';
 import { PointCal } from 'point2point';
 import { CameraEvent, CameraState } from 'src/camera-observer';
 import { BoardCamera } from 'src/board-camera/interface';
@@ -164,7 +164,11 @@ export default class BoardCameraV2 implements BoardCamera {
     }
 
     convertFromViewPort2WorldSpace(point: Point): Point{
-        return convert2WorldSpace(point, this._viewPortWidth, this._viewPortHeight, this._position, this._zoomLevel, this._rotation);
+        return convert2WorldSpaceAnchorAtCenter(point, this._position, this._zoomLevel, this._rotation);
+    }
+
+    convertFromWorldSpace2ViewPort(point: Point): Point{
+        return convert2ViewPortSpaceAnchorAtCenter(point, this._position, this._zoomLevel, this._rotation);
     }
     
     invertFromWorldSpace2ViewPort(point: Point): Point{

--- a/src/board-camera/utils/coordinate-conversion.ts
+++ b/src/board-camera/utils/coordinate-conversion.ts
@@ -21,6 +21,22 @@ export function convert2WorldSpace(point: Point, viewPortWidth: number, viewPort
     return PointCal.addVector(cameraPosition, delta2Point);
 }
 
+// the origin of the view port is at the camera position; the point is in view port space (relative to the camera position)
+export function convert2WorldSpaceAnchorAtCenter(point: Point, cameraPosition: Point, cameraZoomLevel: number, cameraRotation: number): Point{
+    const scaledBack = PointCal.multiplyVectorByScalar(point, 1 / cameraZoomLevel);
+    const rotatedBack = PointCal.rotatePoint(scaledBack, cameraRotation);
+    const withOffset = PointCal.addVector(rotatedBack, cameraPosition);
+    return withOffset;
+}
+
+// the origin of the view port is at the camera position; the point is in world space; the returned point is in view port space (relative to the camera position)
+export function convert2ViewPortSpaceAnchorAtCenter(point: Point, cameraPosition: Point, cameraZoomLevel: number, cameraRotation: number): Point{
+    const withOffset = PointCal.subVector(point, cameraPosition);
+    const scaled = PointCal.multiplyVectorByScalar(withOffset, cameraZoomLevel);
+    const rotated = PointCal.rotatePoint(scaled, -cameraRotation);
+    return rotated;
+}
+
 export function invertFromWorldSpace(point: Point, viewPortWidth: number, viewPortHeight: number, cameraPosition: Point, cameraZoomLevel: number, cameraRotation: number): Point{
     let cameraFrameCenter = {x: viewPortWidth / 2, y: viewPortHeight / 2};
     let delta2Point = PointCal.subVector(point, cameraPosition);

--- a/src/board-camera/zoom/zoom.ts
+++ b/src/board-camera/zoom/zoom.ts
@@ -88,10 +88,9 @@ export class BaseZoomHandler extends ZoomHandlerBoilerPlate {
     }
 
     zoomCameraToAt(camera: BoardCamera, to: number, at: Point): void {
-        let originalAnchorInWorld = convert2WorldSpace(at, camera.viewPortWidth, camera.viewPortHeight, camera.position, camera.zoomLevel, camera.rotation);
-        const originalZoomLevel = camera.zoomLevel;
+        let originalAnchorInWorld = camera.convertFromViewPort2WorldSpace(at);
         camera.setZoomLevel(to);
-        let anchorInWorldAfterZoom = convert2WorldSpace(at, camera.viewPortWidth, camera.viewPortHeight, camera.position, camera.zoomLevel, camera.rotation);
+        let anchorInWorldAfterZoom = camera.convertFromViewPort2WorldSpace(at);
         const diff = PointCal.subVector(originalAnchorInWorld, anchorInWorldAfterZoom);
         this.panHandler.panCameraBy(camera, diff);
     }

--- a/src/boardify/board.ts
+++ b/src/boardify/board.ts
@@ -347,28 +347,19 @@ export default class Board {
         }
     }
 
-    private convertWindowPoint2ViewPortPoint(bottomLeftCornerOfCanvas: Point, clickPointInWindow: Point): Point {
-        const res = PointCal.subVector(clickPointInWindow, bottomLeftCornerOfCanvas);
-        if(this._alignCoordinateSystem) {
-            return {x: res.x, y: res.y};
-        } else {
-            return {x: res.x, y: -res.y};
-        }
-    }
-
     /**
      * @translationBlock Converts a point from window coordinates to world coordinates.
      * @param clickPointInWindow The point in window coordinates to convert.
      * @returns The converted point in world coordinates.
      */
     convertWindowPoint2WorldCoord(clickPointInWindow: Point): Point {
-        if(this._alignCoordinateSystem){
-            const pointInCameraViewPort = this.convertWindowPoint2ViewPortPoint({y: this._canvas.getBoundingClientRect().top, x: this._canvas.getBoundingClientRect().left}, clickPointInWindow);
-            return this.boardStateObserver.camera.convertFromViewPort2WorldSpace(pointInCameraViewPort);
-        } else {
-            const pointInCameraViewPort = this.convertWindowPoint2ViewPortPoint({y: this._canvas.getBoundingClientRect().bottom, x: this._canvas.getBoundingClientRect().left}, clickPointInWindow);
-            return this.boardStateObserver.camera.convertFromViewPort2WorldSpace(pointInCameraViewPort);
+        const boundingRect = this._canvas.getBoundingClientRect();
+        const cameraCenterInWindow = {x: boundingRect.left + (boundingRect.right - boundingRect.left) / 2, y: boundingRect.top + (boundingRect.bottom - boundingRect.top) / 2};
+        const pointInViewPort = PointCal.subVector(clickPointInWindow, cameraCenterInWindow);
+        if(!this._alignCoordinateSystem){
+            pointInViewPort.y = -pointInViewPort.y;
         }
+        return this.boardStateObserver.camera.convertFromViewPort2WorldSpace(pointInViewPort);
     }
 
     /**

--- a/src/kmt-strategy/kmt-strategy.ts
+++ b/src/kmt-strategy/kmt-strategy.ts
@@ -188,9 +188,9 @@ export class DefaultBoardKMTStrategy implements BoardKMTStrategy {
                 this.canvas.style.cursor = "grabbing";
             }
             const target = {x: e.clientX, y: e.clientY};
-            let diff = PointCal.subVector(this.dragStartPoint, target);
+            const diff = PointCal.subVector(this.dragStartPoint, target);
             if(!this._alignCoordinateSystem){
-                diff = PointCal.flipYAxis(diff);
+                diff.y = -diff.y;
             }
             let diffInWorld = PointCal.rotatePoint(diff, this._camera.rotation);
             diffInWorld = PointCal.multiplyVectorByScalar(diffInWorld, 1 / this._camera.zoomLevel);
@@ -210,9 +210,9 @@ export class DefaultBoardKMTStrategy implements BoardKMTStrategy {
             //NOTE this is panning the camera
             // console.log("panning?: ", (Math.abs(e.deltaY) % 40 !== 0 || Math.abs(e.deltaY) == 0) ? "yes": "no");
             // console.log("panning?", e.deltaMode == 0 ? "yes": "no");
-            let diff = {x: e.deltaX, y: e.deltaY};
+            const diff = {x: e.deltaX, y: e.deltaY};
             if(!this._alignCoordinateSystem){
-                diff = PointCal.flipYAxis(diff);
+                diff.y = -diff.y;
             }
             let diffInWorld = PointCal.rotatePoint(diff, this._camera.rotation);
             diffInWorld = PointCal.multiplyVectorByScalar(diffInWorld, 1 / this._camera.zoomLevel);
@@ -224,10 +224,12 @@ export class DefaultBoardKMTStrategy implements BoardKMTStrategy {
                 return;
             }
             const cursorPosition = {x: e.clientX, y: e.clientY};
-            let anchorPoint = PointCal.subVector(cursorPosition, {x: this.canvas.getBoundingClientRect().left, y: this.canvas.getBoundingClientRect().top});
+            // anchor point is in view port space (relative to the camera position)
+            const boundingRect = this._canvas.getBoundingClientRect();
+            const cameraCenterInWindow = {x: boundingRect.left + (boundingRect.right - boundingRect.left) / 2, y: boundingRect.top + (boundingRect.bottom - boundingRect.top) / 2};
+            const anchorPoint = PointCal.subVector(cursorPosition, cameraCenterInWindow);
             if(!this._alignCoordinateSystem){
-                anchorPoint = PointCal.subVector(cursorPosition, {x: this.canvas.getBoundingClientRect().left, y: this.canvas.getBoundingClientRect().bottom});
-                anchorPoint = PointCal.flipYAxis(anchorPoint);
+                anchorPoint.y = -anchorPoint.y;
             }
             // const zoomLevel = this._camera.zoomLevel - (this._camera.zoomLevel * zoomAmount * 5);
             this.inputObserver.notifyOnZoom(this._camera, -(this._camera.zoomLevel * zoomAmount * 5), anchorPoint);

--- a/tests/board-camera/camera-utils.test.ts
+++ b/tests/board-camera/camera-utils.test.ts
@@ -1,4 +1,4 @@
-import { withinBoundaries, normalizeAngleZero2TwoPI, angleSpan, convert2WorldSpace, invertFromWorldSpace } from "../../src/board-camera";
+import { withinBoundaries, normalizeAngleZero2TwoPI, angleSpan, convert2WorldSpace, invertFromWorldSpace, convert2WorldSpaceAnchorAtCenter, convert2ViewPortSpaceAnchorAtCenter } from "../../src/board-camera";
 import { clampRotation, RotationLimits } from "../../src/board-camera/utils/rotation";
 
 import { Boundaries, halfTranslationWidthOf, translationWidthOf, translationHeightOf, halfTranslationHeightOf } from "../../src/board-camera/utils/position";
@@ -137,6 +137,15 @@ describe("coordinate conversion", () => {
         expect(testRes2.y).toBeCloseTo(-390);
     });
 
+    test("Convert point within camera view to world space with the camera position as view port origin", ()=>{
+        const testRes = convert2WorldSpaceAnchorAtCenter({x: -400, y: -400},  {x: 30, y: 50}, 10, -45 * Math.PI / 180);
+        expect(testRes.x).toBeCloseTo(30 - (800 / (Math.sqrt(2) * 10)));
+        expect(testRes.y).toBeCloseTo(50);
+        const testRes2 = convert2WorldSpaceAnchorAtCenter({x: -400, y: -400}, {x: 10, y: 10}, 1, 0);
+        expect(testRes2.x).toBeCloseTo(-390);
+        expect(testRes2.y).toBeCloseTo(-390);
+    });
+
     test("Convert point within world space to camera view", ()=>{
         const point = {x: 10, y: 30};
         const cameraCenterInViewPort = {x: 500, y: 500};
@@ -146,6 +155,18 @@ describe("coordinate conversion", () => {
         const test2Point = {x: 10, y: 50};
         const testRes2 = invertFromWorldSpace(test2Point, 1000, 1000, {x: 30, y: 50}, 1, -45 * Math.PI / 180);
         const expectedRes = {x: 500 - 20 / Math.sqrt(2), y: 500 - 20 / Math.sqrt(2)};
+        expect(testRes2.x).toBeCloseTo(expectedRes.x);
+        expect(testRes2.y).toBeCloseTo(expectedRes.y);
+    });
+
+    test("Convert point within world space to camera view with camera position as viewport origin", ()=>{
+        const point = {x: 10, y: 30};
+        const testRes = convert2ViewPortSpaceAnchorAtCenter(point, {x: 30, y: 50}, 1, 0);
+        expect(testRes.x).toBeCloseTo(-20);
+        expect(testRes.y).toBeCloseTo(-20);
+        const test2Point = {x: 10, y: 50};
+        const testRes2 = convert2ViewPortSpaceAnchorAtCenter(test2Point, {x: 30, y: 50}, 1, -45 * Math.PI / 180);
+        const expectedRes = {x: - 20 / Math.sqrt(2), y: - 20 / Math.sqrt(2)};
         expect(testRes2.x).toBeCloseTo(expectedRes.x);
         expect(testRes2.y).toBeCloseTo(expectedRes.y);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,6 @@
         "noEmitOnError": true,
         "noImplicitAny": true
     },
-    "include": [ "src/**/*" ],
+    "include": [ "src/**/*", "devserver/**/*", "main.ts"],
     "exclude": ["node_modules", "**/*.test.ts", "dist", "build"]
 }


### PR DESCRIPTION
The conversion of the coordinate system used the bottom left corner of the viewport as the origin for the viewport space. This adds unnecessary calculation and cognitive load when doing the coordinate system conversion. One has to take into the account of `alignCoordinateSystem` and change both the interest point and the origin to correctly represent the current coordinate system of the viewport. 

Changing the origin to the position of the camera (the center of the viewport) takes that burden off.