### PR TITLE
refactor: reorder context transformation

### DIFF
--- a/devserver/pixi-test.ts
+++ b/devserver/pixi-test.ts
@@ -4,6 +4,7 @@ import { Application, Assets, Graphics, Matrix, Sprite } from 'pixi.js';
 import { DefaultBoardKMTStrategyWithoutSelection } from 'src/kmt-strategy';
 import { createDefaultInputObserverWithCamera } from 'src/input-observer';
 
+console.log("pixi-test");
 // Asynchronous IIFE
 (async () =>
 {
@@ -44,7 +45,7 @@ import { createDefaultInputObserverWithCamera } from 'src/input-observer';
 
     // Add to stage.
     // console.log(camera.contextTransform);
-    const transform = camera.getTransform(app.screen.width, app.screen.height, 1, true);
+    const transform = camera.getTransform(1, true);
     app.stage.setFromMatrix(new Matrix(transform.a, transform.b, transform.c, transform.d, transform.e, transform.f));
 
     app.stage.addChild(bunny);
@@ -66,7 +67,7 @@ import { createDefaultInputObserverWithCamera } from 'src/input-observer';
          * Here we use deltaTime, which is the time elapsed between the frame callbacks
          * to create frame-independent transformation. Keeping the speed consistent.
          */
-        const transform = camera.getTransform(app.screen.width, app.screen.height, 1, true);
+        const transform = camera.getTransform(1, true);
         app.stage.setFromMatrix(new Matrix(transform.a, transform.b, transform.c, transform.d, transform.e, transform.f));
     });
 })();

--- a/devserver/pixi-test.ts
+++ b/devserver/pixi-test.ts
@@ -19,7 +19,7 @@ console.log("pixi-test");
     // console.log(app.canvas.width, app.canvas.height);
     // app.renderer.events.autoPreventDefault = true;
     
-    const camera = new DefaultBoardCamera({x: 100, y: 100}, 0, 2, app.screen.width, app.screen.height);
+    const camera = new DefaultBoardCamera(app.screen.width, app.screen.height, {x: 100, y: 100}, 0, 2);
 
     const kmtStrategy = new DefaultBoardKMTStrategyWithoutSelection(app.canvas, app.canvas, createDefaultInputObserverWithCamera(camera), false, true)
     kmtStrategy.setUp();

--- a/src/board-camera/board-camera-v2.ts
+++ b/src/board-camera/board-camera-v2.ts
@@ -161,6 +161,14 @@ export default class DefaultBoardCamera implements BoardCamera {
         this._rotationBoundaries = rotationBoundaries;
     }
 
+    /**
+     * The order of the transformation is as follows:
+     * 1. Translation (move the origin of the context to the center of the canvas)
+     * 2. Scale (scale the context using the device pixel ratio)
+     * 3. Rotation (rotate the context negatively the rotation of the camera)
+     * 4. Zoom (scale the context using the zoom level of the camera)
+     * 5. Translation (move the origin of the context to the position of the camera in the context coordinate system)
+     */
     getTransform(canvasWidth: number, canvasHeight: number, devicePixelRatio: number, alignCoorindate: boolean) {
         const tx = canvasWidth / 2;
         const ty = canvasHeight / 2;
@@ -181,29 +189,6 @@ export default class DefaultBoardCamera implements BoardCamera {
         const e = s * s2 * cos * tx2 - s * s2 * sin * ty2 + tx;
         const f = s * s2 * sin * tx2 + s * s2 * cos * ty2 + ty;
         return {a, b, c, d, e, f};
-    }
-
-    get contextTransform() {
-        return this.getContextTransform(this._viewPortWidth, this._viewPortHeight, window.devicePixelRatio);
-    }
-
-    getContextTransform(canvasWidth: number, canvasHeight: number, devicePixelRatio: number) {
-        const translation = {
-            x: (canvasWidth / 2) - this._position.x * devicePixelRatio * this._zoomLevel,
-            y: (canvasHeight / 2) - (this._position.y * devicePixelRatio * this._zoomLevel)
-        };
-    
-        const scale = {
-            x: devicePixelRatio * this._zoomLevel,
-            y: devicePixelRatio * this._zoomLevel
-        };
-    
-        const rotation = -this._rotation;
-        return {
-            position: translation,
-            rotation: rotation,
-            zoomLevel: scale.x
-        }
     }
 
     setRotation(rotation: number){

--- a/src/board-camera/board-camera-v2.ts
+++ b/src/board-camera/board-camera-v2.ts
@@ -36,7 +36,7 @@ export default class DefaultBoardCamera implements BoardCamera {
      * @param zoomLevelBoundaries The boundaries of the zoom level of the camera
      * @param rotationBoundaries The boundaries of the rotation of the camera
      */
-    constructor(position: Point = {x: 0, y: 0}, rotation: number = 0, zoomLevel: number = 1, viewPortWidth: number = 1000, viewPortHeight: number = 1000, observer: CameraObserver = new CameraObserver(), boundaries: Boundaries = {min: {x: -10000, y: -10000}, max: {x: 10000, y: 10000}}, zoomLevelBoundaries: ZoomLevelLimits = {min: 0.1, max: 10}, rotationBoundaries: RotationLimits = undefined){
+    constructor(viewPortWidth: number = 1000, viewPortHeight: number = 1000, position: Point = {x: 0, y: 0}, rotation: number = 0, zoomLevel: number = 1,  observer: CameraObserver = new CameraObserver(), boundaries: Boundaries = {min: {x: -10000, y: -10000}, max: {x: 10000, y: 10000}}, zoomLevelBoundaries: ZoomLevelLimits = {min: 0.1, max: 10}, rotationBoundaries: RotationLimits = undefined){
         this._position = position;
         this._zoomLevel = zoomLevel;
         this._rotation = rotation;

--- a/src/board-camera/board-camera-v2.ts
+++ b/src/board-camera/board-camera-v2.ts
@@ -25,6 +25,17 @@ export default class DefaultBoardCamera implements BoardCamera {
     private _observer: CameraObserver;
 
 
+    /**
+     * @param position The position of the camera in the world coordinate system
+     * @param rotation The rotation of the camera in the world coordinate system
+     * @param zoomLevel The zoom level of the camera
+     * @param viewPortWidth The width of the viewport. (The width of the canvas in css pixels)
+     * @param viewPortHeight The height of the viewport. (The height of the canvas in css pixels)
+     * @param observer The observer of the camera
+     * @param boundaries The boundaries of the camera in the world coordinate system
+     * @param zoomLevelBoundaries The boundaries of the zoom level of the camera
+     * @param rotationBoundaries The boundaries of the rotation of the camera
+     */
     constructor(position: Point = {x: 0, y: 0}, rotation: number = 0, zoomLevel: number = 1, viewPortWidth: number = 1000, viewPortHeight: number = 1000, observer: CameraObserver = new CameraObserver(), boundaries: Boundaries = {min: {x: -10000, y: -10000}, max: {x: 10000, y: 10000}}, zoomLevelBoundaries: ZoomLevelLimits = {min: 0.1, max: 10}, rotationBoundaries: RotationLimits = undefined){
         this._position = position;
         this._zoomLevel = zoomLevel;
@@ -162,16 +173,20 @@ export default class DefaultBoardCamera implements BoardCamera {
     }
 
     /**
-     * The order of the transformation is as follows:
-     * 1. Translation (move the origin of the context to the center of the canvas)
-     * 2. Scale (scale the context using the device pixel ratio)
+     * @translationBlock The order of the transformation is as follows:
+     * 1. Scale (scale the context using the device pixel ratio)
+     * 2. Translation (move the origin of the context to the center of the canvas)
      * 3. Rotation (rotate the context negatively the rotation of the camera)
      * 4. Zoom (scale the context using the zoom level of the camera)
      * 5. Translation (move the origin of the context to the position of the camera in the context coordinate system)
+     * 
+     * @param devicePixelRatio The device pixel ratio of the canvas
+     * @param alignCoorindate Whether to align the coordinate system to the camera's position
+     * @returns The transformation matrix
      */
-    getTransform(canvasWidth: number, canvasHeight: number, devicePixelRatio: number, alignCoorindate: boolean) {
-        const tx = canvasWidth / 2;
-        const ty = canvasHeight / 2;
+    getTransform(devicePixelRatio: number, alignCoorindate: boolean) {
+        const tx = devicePixelRatio * this._viewPortWidth / 2;
+        const ty = devicePixelRatio * this._viewPortHeight / 2;
         const tx2 = -this._position.x;
         const ty2 = alignCoorindate ? -this._position.y : this._position.y;
 

--- a/src/board-camera/interface.ts
+++ b/src/board-camera/interface.ts
@@ -17,11 +17,6 @@ export interface BoardCamera {
     zoomBoundaries?: ZoomLevelLimits;
     rotationBoundaries?: RotationLimits;
     observer: CameraObserver;
-    contextTransform: {
-        position: Point;
-        rotation: number;
-        zoomLevel: number;
-    };
     setPosition(destination: Point): void;
     setPositionByDelta(delta: Point): void;
     setZoomLevel(zoomLevel: number): void;

--- a/src/board-camera/interface.ts
+++ b/src/board-camera/interface.ts
@@ -27,6 +27,6 @@ export interface BoardCamera {
     getCameraOriginInWindow(centerInWindow: Point): Point;
     convertFromViewPort2WorldSpace(point: Point): Point;
     convertFromWorld2ViewPort(point: Point): Point;
-    getTransform(canvasWidth: number, canvasHeight: number, devicePixelRatio: number, alignCoordinateSystem: boolean): {a: number, b: number, c: number, d: number, e: number, f: number};
+    getTransform(devicePixelRatio: number, alignCoordinateSystem: boolean): {a: number, b: number, c: number, d: number, e: number, f: number};
     on<K extends keyof CameraEvent>(eventName: K, callback: (event: CameraEvent[K], cameraState: CameraState)=>void): UnSubscribe;
 }

--- a/src/boardify/board.ts
+++ b/src/boardify/board.ts
@@ -314,7 +314,7 @@ export default class Board {
         }
         this._context.clearRect(curBoundaries.min.x, -curBoundaries.min.y, curBoundaries.max.x - curBoundaries.min.x, -(curBoundaries.max.y - curBoundaries.min.y));
 
-        const transfromMatrix = this.boardStateObserver.camera.getTransform(this._canvas.width, this._canvas.height, window.devicePixelRatio, this._alignCoordinateSystem);
+        const transfromMatrix = this.boardStateObserver.camera.getTransform(window.devicePixelRatio, this._alignCoordinateSystem);
         this._context.setTransform(transfromMatrix.a, transfromMatrix.b, transfromMatrix.c, transfromMatrix.d, transfromMatrix.e, transfromMatrix.f);
     }
 


### PR DESCRIPTION
Reorder of transformation applied on the canvas context to be: 
1. Scale the context with `devicePixelRatio`.
2. Translate the origin of the context to the center of the canvas.
3. Rotation (rotate the context negatively the rotation of the camera)
4. Scale the context using the zoom level of the camera
5. Translate the origin of the context to the position of the camera in the context coordinate system