### PR TITLE
feat: add helper function to get smooth camera position

### DIFF
--- a/devserver/index.html
+++ b/devserver/index.html
@@ -15,7 +15,7 @@
         <button id="reset-camera-btn">重置相機</button>
         <button id="record">錄製</button>
         <button id="download">下載影片</button>
-        <button id="experimental-zoom-handler-btn">實驗性相機</button>
+        <button id="experimental-zoom-handler-btn">對原點縮放</button>
       </div>
     </div>
     <script type="module" src="/main.ts"></script>

--- a/src/board-camera/utils/coordinate-conversion.ts
+++ b/src/board-camera/utils/coordinate-conversion.ts
@@ -60,3 +60,9 @@ export function convertDeltaInViewPortToWorldSpace(delta: Point, cameraZoomLevel
 export function convertDeltaInWorldToViewPortSpace(delta: Point, cameraZoomLevel: number, cameraRotation: number): Point{
     return PointCal.multiplyVectorByScalar(PointCal.rotatePoint(delta, -cameraRotation), cameraZoomLevel);
 }
+
+export function cameraPositionToGet(pointInWorld: Point, toPointInViewPort: Point, cameraZoomLevel: number, cameraRotation: number): Point {
+    const scaled = PointCal.multiplyVectorByScalar(toPointInViewPort, 1 / cameraZoomLevel);
+    const rotated = PointCal.rotatePoint(scaled, cameraRotation);
+    return PointCal.subVector(pointInWorld, rotated);
+}


### PR DESCRIPTION
When the pan and zoom are separately controlled the overall result is weird.
The reason being that the zoom would cause the camera to lose sight of the target point. (zoom would also pan if it's zooming at a certain point instead of the center of the viewport.)
One other thing is that the camera does not have the ability to move camera so a point in world would appear in a specified location of the viewport. 
Problem Statement: Givent a world point and a viewport point; the camera rotation and zoom level are fixed. find the camera position so that the world point appears at the viewport point.