### PR TITLE
refactor: expose camera rig configs from board; refactor state machine

### DIFF
--- a/devserver/main.ts
+++ b/devserver/main.ts
@@ -1,16 +1,15 @@
 import "./media";
-import Board, { drawAxis, drawRuler, drawGrid } from "src/boardify";
+import Board from "src/boardify";
 import { CanvasPositionDimensionPublisher } from "src/boardify/utils";
 import { Point, PointCal } from "point2point";
-import { drawVectorTip, drawXAxis, drawYAxis, drawArrow } from "./drawing-util";
-import { drawLine } from "./utils";
-import { Container, SelectionBox } from "src/drawing-engine";
+import { drawXAxis, drawYAxis } from "./drawing-util";
+import { Container } from "src/drawing-engine";
 import { Animation, CompositeAnimation, PointAnimationHelper, Keyframe, EasingFunctions, NumberAnimationHelper } from "@niuee/bounce";
 import { FlowControlWithAnimationAndLockInput } from "src/input-flow-control/flow-control-with-animation-and-lock";
 import { createDefaultZoomToAtWorldHandler } from "src/board-camera/zoom/zoom-handler";
 import { createDefaultPanByHandler } from "src/board-camera/pan/pan-handlers";
 import { cameraPositionToGet, convertDeltaInViewPortToWorldSpace } from "src";
-import type { BoardCamera, ZoomHandlerConfig } from "src/board-camera";
+import type { ZoomHandlerConfig } from "src/board-camera";
 
 export function comboDetect(inputKey: string, currentString: string, combo: string): {nextState: string, comboDetected: boolean} {
     if(currentString.length > combo.length){
@@ -35,7 +34,7 @@ const canvas = document.getElementById("graph") as HTMLCanvasElement;
 const canvasPositionDimensionPublisher = new CanvasPositionDimensionPublisher(canvas);
 const board = new Board(canvas);
 board.camera.setRotation(0 * Math.PI / 180);
-board.alignCoordinateSystem = true;
+board.alignCoordinateSystem = false;
 console.log("context", board.context);
 const drawingEngine = new Container(board.context);
 
@@ -55,7 +54,8 @@ const config: ZoomHandlerConfig = {
 const positionKeyframe: Keyframe<Point>[] = [{percentage: 0, value: {x: board.camera.position.x, y: board.camera.position.y}, easingFn: EasingFunctions.linear}];
 const zoomKeyframe: Keyframe<number>[] = [{percentage: 0, value: board.camera.zoomLevel, easingFn: EasingFunctions.linear}];
 const rotationKeyframe: Keyframe<number>[] = [{percentage: 0, value: board.camera.rotation, easingFn: EasingFunctions.linear}];
-
+// board.restrictXTranslation = true;
+board.restrictYTranslation = true;
 const animation = new Animation(positionKeyframe, (value)=>{
     // const pointInWorld = board.camera.convertFromViewPort2WorldSpace(value);
     // (board.controlCenter as RelayControlCenter).notifyPanToAnimationInput(value);
@@ -183,7 +183,7 @@ function step(timestamp: number){
     drawingEngine.drawWithContext(board.context, deltaMiliseconds);
 
     const fourCorners = calculateTopFourCorners();
-    drawRuler(board.context, fourCorners.topLeft, fourCorners.topRight, fourCorners.bottomLeft, fourCorners.bottomRight, true, board.camera.zoomLevel);
+    // drawRuler(board.context, fourCorners.topLeft, fourCorners.topRight, fourCorners.bottomLeft, fourCorners.bottomRight, true, board.camera.zoomLevel);
     // layout.render(result);
     // board.context.strokeStyle = 'red';
     // board.context.beginPath();

--- a/src/being/interfaces.ts
+++ b/src/being/interfaces.ts
@@ -179,7 +179,7 @@ export class TemplateStateMachine<EventPayloadMapping, Context extends BaseConte
         this._currentState = state;
     }
     
-    happens<K extends keyof EventPayloadMapping>(event: K, payload: EventPayloadMapping[K], context: Context): States | undefined {
+    happens<K extends keyof EventPayloadMapping>(event: K, payload: EventPayloadMapping[K]): States | undefined {
         this._happensCallbacks.forEach(callback => callback(event, payload, this._context));
         const nextState = this._states[this._currentState].handles(event, payload, this._context);
         if(nextState !== undefined && nextState !== this._currentState){

--- a/src/input-flow-control/flow-control-with-animation-and-lock.ts
+++ b/src/input-flow-control/flow-control-with-animation-and-lock.ts
@@ -211,7 +211,7 @@ export class CameraRig implements PanContext, ZoomContext { // this is used as a
         return this._camera;
     }
 
-    get config(): PanHandlerConfig & BaseZoomHandlerConfig {
+    get config(): CameraRigConfig {
         return this._config;
     }
 

--- a/src/input-flow-control/pan-control-state-machine.ts
+++ b/src/input-flow-control/pan-control-state-machine.ts
@@ -78,7 +78,7 @@ export class PanControlStateMachine extends TemplateStateMachine<PanEventPayload
      * @category Input Flow Control
      */
     notifyPanInput(diff: Point): void{
-        this.happens("userPanByInput", {diff: diff}, this._context);
+        this.happens("userPanByInput", {diff: diff});
     }
 
     /**
@@ -87,7 +87,7 @@ export class PanControlStateMachine extends TemplateStateMachine<PanEventPayload
      * @category Input Flow Control
      */
     notifyPanToAnimationInput(target: Point): void{
-        this.happens("transitionPanToInput", {target: target}, this._context);
+        this.happens("transitionPanToInput", {target: target});
     }
 
     /**
@@ -96,7 +96,7 @@ export class PanControlStateMachine extends TemplateStateMachine<PanEventPayload
      * @category Input Flow Control
      */
     initateTransition(): void{
-        this.happens("initateTransition", {}, this._context);
+        this.happens("initateTransition", {});
     }
 
     set limitEntireViewPort(limit: boolean){

--- a/src/input-flow-control/zoom-control-state-machine.ts
+++ b/src/input-flow-control/zoom-control-state-machine.ts
@@ -220,23 +220,23 @@ export class ZoomControlStateMachine extends TemplateStateMachine<ZoomEventPaylo
     }
 
     notifyZoomByAtInput(delta: number, at: Point): void {
-        this.happens("userZoomByAtInput", {deltaZoom: delta, anchorPoint: at}, this._context);
+        this.happens("userZoomByAtInput", {deltaZoom: delta, anchorPoint: at});
     }
 
     notifyZoomByAtInputAnimation(delta: number, at: Point): void {
-        this.happens("transitionZoomByAtInput", {deltaZoom: delta, anchorPoint: at}, this._context);
+        this.happens("transitionZoomByAtInput", {deltaZoom: delta, anchorPoint: at});
     }
 
     notifyZoomToAtCenterInput(targetZoom: number, at: Point): void {
-        this.happens("transitionZoomToAtCenterInput", {targetZoom: targetZoom, anchorPoint: at}, this._context);
+        this.happens("transitionZoomToAtCenterInput", {targetZoom: targetZoom, anchorPoint: at});
     }
 
     notifyZoomToAtWorldInput(targetZoom: number, at: Point): void {
-        this.happens("transitionZoomToAtWorldInput", {targetZoom: targetZoom, anchorPoint: at}, this._context);
+        this.happens("transitionZoomToAtWorldInput", {targetZoom: targetZoom, anchorPoint: at});
     }
 
     initateTransition(): void {
-        this.happens("initiateTransition", {}, this._context);
+        this.happens("initiateTransition", {});
     }
 }
 

--- a/src/input-state-machine/kmt-input-state-machine.ts
+++ b/src/input-state-machine/kmt-input-state-machine.ts
@@ -1,4 +1,4 @@
-import { BaseContext, EventReactions, EventGuards, Guard, State, StateMachine, TemplateState, TemplateStateMachine } from "../being/interfaces";
+import { EventReactions, EventGuards, Guard, TemplateState, TemplateStateMachine } from "../being/interfaces";
 import { Point } from "src/util/misc";
 import { PointCal } from "point2point";
 import { KmtInputContext } from "./kmt-input-context";
@@ -422,37 +422,14 @@ export class PanViaScrollWheelState extends TemplateState<KmtInputEventMapping, 
     }
 }
 
-/**
- * @description The keyboard mouse and trackpad input state machine.
- * 
- * @category Input State Machine
- */
-export class KmtInputStateMachine<EventPayloadMapping, Context extends BaseContext, States extends string = 'IDLE'> extends TemplateStateMachine<EventPayloadMapping, Context, States> {
-
-
-    constructor(states: Record<States, State<EventPayloadMapping, Context, States>>, initialState: States, context: Context) {
-        super(states, initialState, context);
-    }
-
-    setContext(context: Context): void {
-        this._context = context;
-    }
-
-    get possibleStates(): States[] {
-        return this._statesArray;
-    }
-
-    get states(): Record<States, State<EventPayloadMapping, Context, States>> {
-        return this._states;
-    }
-}
+export type KmtInputStateMachine = TemplateStateMachine<KmtInputEventMapping, KmtInputContext, KmtInputStates>;
 
 /**
  * @description Creates the keyboard mouse and trackpad input state machine.
  * 
  * @category Input State Machine
  */
-export function createKmtInputStateMachine(context: KmtInputContext): TemplateStateMachine<KmtInputEventMapping, KmtInputContext, KmtInputStates> {
+export function createKmtInputStateMachine(context: KmtInputContext): KmtInputStateMachine {
     const states = {
         IDLE: new KmtIdleState(),
         READY_TO_PAN_VIA_SPACEBAR: new ReadyToPanViaSpaceBarState(),

--- a/src/input-state-machine/touch-input-state-machine.ts
+++ b/src/input-state-machine/touch-input-state-machine.ts
@@ -215,14 +215,13 @@ export class InProgressState extends TemplateState<TouchEventMapping, TouchConte
  * 
  * @category Input State Machine
  */
-export class TouchInputStateMachine extends TemplateStateMachine<TouchEventMapping, TouchContext, TouchStates> {
+export type TouchInputStateMachine = TemplateStateMachine<TouchEventMapping, TouchContext, TouchStates>;
 
-    constructor(context: TouchContext) {
-        super({
+export function createTouchInputStateMachine(context: TouchContext): TouchInputStateMachine {
+    return new TemplateStateMachine<TouchEventMapping, TouchContext, TouchStates>(
+        {
             IDLE: new IdleState(),
             PENDING: new PendingState(),
             IN_PROGRESS: new InProgressState(),
         }, "IDLE", context);
-    }
-
 }

--- a/src/kmt-event-parser/vanilla-kmt-event-parser.ts
+++ b/src/kmt-event-parser/vanilla-kmt-event-parser.ts
@@ -1,8 +1,4 @@
-import { KmtInputStateMachine } from "src/input-state-machine";
-import { KmtIdleState, InitialPanState, PanState, PanViaScrollWheelState, ReadyToPanViaScrollWheelState, ReadyToPanViaSpaceBarState } from "src/input-state-machine";
-import { ObservableInputTracker} from "src/input-state-machine/kmt-input-context";
-import type { KmtInputEventMapping, KmtInputContext, KmtInputStates } from "src/input-state-machine";
-import { RawUserInputPublisher } from "src/raw-input-publisher/raw-input-publisher";
+import type { KmtInputStateMachine } from "src/input-state-machine";
 
 /**
  * @category Event Parser
@@ -10,9 +6,7 @@ import { RawUserInputPublisher } from "src/raw-input-publisher/raw-input-publish
 
 export interface KMTEventParser {
     disabled: boolean;
-    debugMode: boolean;
-    alignCoordinateSystem: boolean;
-    stateMachine: KmtInputStateMachine<KmtInputEventMapping, KmtInputContext, KmtInputStates>;
+    stateMachine: KmtInputStateMachine;
     setUp(): void;
     tearDown(): void;
 }
@@ -68,6 +62,7 @@ export type EventTargetWithPointerEvents = {
     removeEventListener: (type: string, listener: (event: any) => void) => void;
 };
 
+
 /**
  * @description The vanilla keyboard mouse and trackpad(KMT) event parser.
  * This parser converts the raw events to events that can be used by the input state machine.
@@ -77,41 +72,18 @@ export type EventTargetWithPointerEvents = {
 export class VanillaKMTEventParser implements KMTEventParser {
 
     private _disabled: boolean;
-    private _debugMode: boolean;
 
-    private _inputTracker: ObservableInputTracker;
-    private _stateMachine: KmtInputStateMachine<KmtInputEventMapping, KmtInputContext, KmtInputStates>;
+    private _stateMachine: KmtInputStateMachine;
 
     private _keyfirstPressed: Map<string, boolean>;
 
     private _eventTarget: EventTargetWithPointerEvents;
 
-    constructor(canvas: HTMLCanvasElement, eventTarget: EventTargetWithPointerEvents, inputPublisher: RawUserInputPublisher, debugMode: boolean = false){
-        this._debugMode = debugMode;
+    constructor(eventTarget: EventTargetWithPointerEvents, stateMachine: KmtInputStateMachine){
         this.bindFunctions();
-        this._inputTracker = new ObservableInputTracker(canvas, inputPublisher);
-        this._stateMachine =  new KmtInputStateMachine<KmtInputEventMapping, KmtInputContext, KmtInputStates>(
-            {
-                IDLE: new KmtIdleState(),
-                READY_TO_PAN_VIA_SPACEBAR: new ReadyToPanViaSpaceBarState(),
-                INITIAL_PAN: new InitialPanState(),
-                PAN: new PanState(),
-                READY_TO_PAN_VIA_SCROLL_WHEEL: new ReadyToPanViaScrollWheelState(),
-                PAN_VIA_SCROLL_WHEEL: new PanViaScrollWheelState(),
-            },
-            "IDLE",
-            this._inputTracker
-        );
+        this._stateMachine = stateMachine;
         this._keyfirstPressed = new Map();
         this._eventTarget = eventTarget;
-    }
-
-    get debugMode(): boolean {
-        return this._debugMode;
-    }
-
-    set debugMode(value: boolean){
-        this._debugMode = value;
     }
 
     get disabled(): boolean {
@@ -122,20 +94,8 @@ export class VanillaKMTEventParser implements KMTEventParser {
         this._disabled = value;
     }
 
-    get inputTracker(): ObservableInputTracker {
-        return this._inputTracker;
-    }
-
-    get stateMachine(): KmtInputStateMachine<KmtInputEventMapping, KmtInputContext, KmtInputStates> {
+    get stateMachine(): KmtInputStateMachine {
         return this._stateMachine;
-    }
-
-    set alignCoordinateSystem(value: boolean){
-        this._inputTracker.alignCoordinateSystem = value;
-    }
-
-    get alignCoordinateSystem(): boolean {
-        return this._inputTracker.alignCoordinateSystem;
     }
 
     setUp(): void {

--- a/src/kmt-event-parser/vanilla-kmt-event-parser.ts
+++ b/src/kmt-event-parser/vanilla-kmt-event-parser.ts
@@ -174,11 +174,11 @@ export class VanillaKMTEventParser implements KMTEventParser {
             return;
         }
         if(e.button === 0 && e.pointerType === "mouse"){
-            this.stateMachine.happens("leftPointerDown", {x: e.clientX, y: e.clientY}, this._inputTracker);
+            this.stateMachine.happens("leftPointerDown", {x: e.clientX, y: e.clientY});
             return;
         }
         if(e.button === 1 && e.pointerType === "mouse"){
-            this.stateMachine.happens("middlePointerDown", {x: e.clientX, y: e.clientY}, this._inputTracker);
+            this.stateMachine.happens("middlePointerDown", {x: e.clientX, y: e.clientY});
             return;
         }
     }
@@ -188,11 +188,11 @@ export class VanillaKMTEventParser implements KMTEventParser {
             return;
         }
         if(e.button === 0 && e.pointerType === "mouse"){
-            this.stateMachine.happens("leftPointerUp", {x: e.clientX, y: e.clientY}, this._inputTracker);
+            this.stateMachine.happens("leftPointerUp", {x: e.clientX, y: e.clientY});
             return;
         }
         if(e.button === 1 && e.pointerType === "mouse"){
-            this.stateMachine.happens("middlePointerUp", {x: e.clientX, y: e.clientY}, this._inputTracker);
+            this.stateMachine.happens("middlePointerUp", {x: e.clientX, y: e.clientY});
             return;
         }
     }
@@ -202,11 +202,11 @@ export class VanillaKMTEventParser implements KMTEventParser {
             return;
         }
         if(e.buttons === 1 && e.pointerType === "mouse"){
-            this.stateMachine.happens("leftPointerMove", {x: e.clientX, y: e.clientY}, this._inputTracker);
+            this.stateMachine.happens("leftPointerMove", {x: e.clientX, y: e.clientY});
             return;
         }
         if(e.buttons === 4 && e.pointerType === "mouse"){
-            this.stateMachine.happens("middlePointerMove", {x: e.clientX, y: e.clientY}, this._inputTracker);
+            this.stateMachine.happens("middlePointerMove", {x: e.clientX, y: e.clientY});
             return;
         }
     }
@@ -215,9 +215,9 @@ export class VanillaKMTEventParser implements KMTEventParser {
         if(this._disabled) return;
         e.preventDefault();
         if(e.ctrlKey){
-            this.stateMachine.happens("scrollWithCtrl", {x: e.clientX, y: e.clientY, deltaX: e.deltaX, deltaY: e.deltaY}, this._inputTracker);
+            this.stateMachine.happens("scrollWithCtrl", {x: e.clientX, y: e.clientY, deltaX: e.deltaX, deltaY: e.deltaY});
         } else {
-            this.stateMachine.happens("scroll", {deltaX: e.deltaX, deltaY: e.deltaY}, this._inputTracker);
+            this.stateMachine.happens("scroll", {deltaX: e.deltaX, deltaY: e.deltaY});
         }
     }
 
@@ -228,7 +228,7 @@ export class VanillaKMTEventParser implements KMTEventParser {
         this._keyfirstPressed.set(e.key, true);
         if(e.key === " "){
             e.preventDefault();
-            this.stateMachine.happens("spacebarDown", {}, this._inputTracker);
+            this.stateMachine.happens("spacebarDown", {});
         }
     }
 
@@ -237,7 +237,7 @@ export class VanillaKMTEventParser implements KMTEventParser {
             this._keyfirstPressed.delete(e.key);
         }
         if(e.key === " "){
-            this.stateMachine.happens("spacebarUp", {}, this._inputTracker);
+            this.stateMachine.happens("spacebarUp", {});
         }
     }
 

--- a/src/touch-event-parser/vanilla-touch-event-parser.ts
+++ b/src/touch-event-parser/vanilla-touch-event-parser.ts
@@ -10,7 +10,6 @@ import { TouchInputTracker } from "src/input-state-machine/touch-input-context";
  */
 export interface TouchEventParser {
     disabled: boolean;
-    alignCoordinateSystem: boolean;
     panDisabled: boolean;
     zoomDisabled: boolean;
     rotateDisabled: boolean;
@@ -40,12 +39,10 @@ export class VanillaTouchEventParser implements TouchEventParser {
 
     private touchPointsMap: Map<number, TouchPoints> = new Map<number, TouchPoints>();
 
-    constructor(canvas: HTMLCanvasElement, inputPublisher: RawUserInputPublisher, alignCoordinateSystem: boolean = true){
+    constructor(canvas: HTMLCanvasElement, stateMachine: TouchInputStateMachine){
         this._canvas = canvas;
         this._disabled = false;
-        this._touchInputTracker = new TouchInputTracker(canvas, inputPublisher);
-        this._touchInputTracker.alignCoordinateSystem = alignCoordinateSystem;
-        this.touchSM = new TouchInputStateMachine(this._touchInputTracker);
+        this.touchSM = stateMachine;
 
         this.bindListeners();
     }

--- a/src/touch-event-parser/vanilla-touch-event-parser.ts
+++ b/src/touch-event-parser/vanilla-touch-event-parser.ts
@@ -134,7 +134,7 @@ export class VanillaTouchEventParser implements TouchEventParser {
         for (let i = 0; i < e.changedTouches.length; i++) {
             pointsAdded.push({ident: e.changedTouches[i].identifier, x: e.changedTouches[i].clientX, y: e.changedTouches[i].clientY});
         }
-        this.touchSM.happens("touchstart", {points: pointsAdded}, this._touchInputTracker);
+        this.touchSM.happens("touchstart", {points: pointsAdded});
         e.preventDefault();
     }
 
@@ -146,7 +146,7 @@ export class VanillaTouchEventParser implements TouchEventParser {
         for (let i = 0; i < e.changedTouches.length; i++) {
             pointsRemoved.push({ident: e.changedTouches[i].identifier, x: e.changedTouches[i].clientX, y: e.changedTouches[i].clientY});
         }
-        this.touchSM.happens("touchend", {points: pointsRemoved}, this._touchInputTracker);
+        this.touchSM.happens("touchend", {points: pointsRemoved});
     }
 
     touchendHandler(e: TouchEvent){
@@ -157,7 +157,7 @@ export class VanillaTouchEventParser implements TouchEventParser {
         for (let i = 0; i < e.changedTouches.length; i++) {
             pointsRemoved.push({ident: e.changedTouches[i].identifier, x: e.changedTouches[i].clientX, y: e.changedTouches[i].clientY});
         }
-        this.touchSM.happens("touchend", {points: pointsRemoved}, this._touchInputTracker);
+        this.touchSM.happens("touchend", {points: pointsRemoved});
     }
 
     touchmoveHandler(e: TouchEvent){
@@ -169,6 +169,6 @@ export class VanillaTouchEventParser implements TouchEventParser {
         for (let i = 0; i < e.targetTouches.length; i++) {
             pointsMoved.push({ident: e.targetTouches[i].identifier, x: e.targetTouches[i].clientX, y: e.targetTouches[i].clientY});
         }
-        this.touchSM.happens("touchmove", {points: pointsMoved}, this._touchInputTracker);
+        this.touchSM.happens("touchmove", {points: pointsMoved});
     }
 }


### PR DESCRIPTION
There are two things in this pull request. None of which are breaking change. 
1. Exposed the camera rig configs like `restrictXTranslation` etc. from board. Otherwise, there's no way of configuring the restrictions. Also added the clamping configuration for translation, zoom, and rotation.
2. Refactor the state machine to disallow passing context in runtime