### PR TITLE
refactor: consolidate event parser and input state machine

### DIFF
--- a/src/boardify/board.ts
+++ b/src/boardify/board.ts
@@ -1,5 +1,5 @@
 import DefaultBoardCamera, { ObservableBoardCamera } from 'src/board-camera';
-import { halfTranslationHeightOf, halfTranslationWidthOf, boundariesFullyDefined, } from 'src/board-camera/utils/position';
+import { halfTranslationHeightOf, halfTranslationWidthOf } from 'src/board-camera/utils/position';
 import { KMTEventParser, VanillaKMTEventParser, EventTargetWithPointerEvents } from 'src/kmt-event-parser';
 import { TouchEventParser, VanillaTouchEventParser } from 'src/touch-event-parser';
 import { Point } from 'src/util/misc';
@@ -12,7 +12,7 @@ import { UnsubscribeToUserRawInput, RawUserInputEventMap, RawUserInputPublisher 
 
 import { InputFlowControl, createDefaultFlowControlWithCameraRig } from 'src/input-flow-control';
 import { CameraRig } from 'src/board-camera/camera-rig';
-import { createKmtInputStateMachine, createTouchInputStateMachine, KmtInputStateMachine, ObservableInputTracker, TouchInputStateMachine, TouchInputTracker } from 'src/input-state-machine';
+import { ObservableInputTracker, TouchInputTracker } from 'src/input-state-machine';
 
 /**
  * Usage
@@ -58,8 +58,6 @@ export default class Board {
     private boardInputPublisher: RawUserInputPublisher;
     private _observableInputTracker: ObservableInputTracker;
     private _touchInputTracker: TouchInputTracker;
-    private _touchInputStateMachine: TouchInputStateMachine;
-    private _kmtInputStateMachine: KmtInputStateMachine;
 
     private lastUpdateTime: number = 0;
 
@@ -103,12 +101,9 @@ export default class Board {
 
         this._observableInputTracker = new ObservableInputTracker(canvas, this.boardInputPublisher);
         this._touchInputTracker = new TouchInputTracker(canvas, this.boardInputPublisher);
-
-        this._kmtInputStateMachine = createKmtInputStateMachine(this._observableInputTracker);
-        this._touchInputStateMachine = createTouchInputStateMachine(this._touchInputTracker);
         
-        this._kmtParser = new VanillaKMTEventParser(eventTarget, this._kmtInputStateMachine);
-        this._touchParser = new VanillaTouchEventParser(this._canvas, this._touchInputStateMachine);
+        this._kmtParser = new VanillaKMTEventParser(eventTarget, this._observableInputTracker);
+        this._touchParser = new VanillaTouchEventParser(this._canvas, this._touchInputTracker);
 
         
         // NOTE: device pixel ratio

--- a/src/kmt-event-parser/vanilla-kmt-event-parser.ts
+++ b/src/kmt-event-parser/vanilla-kmt-event-parser.ts
@@ -1,4 +1,5 @@
-import type { KmtInputStateMachine } from "src/input-state-machine";
+import type { KmtInputStateMachine, ObservableInputTracker } from "src/input-state-machine";
+import { createKmtInputStateMachine } from "src/input-state-machine";
 
 /**
  * @category Event Parser
@@ -6,7 +7,6 @@ import type { KmtInputStateMachine } from "src/input-state-machine";
 
 export interface KMTEventParser {
     disabled: boolean;
-    stateMachine: KmtInputStateMachine;
     setUp(): void;
     tearDown(): void;
 }
@@ -79,9 +79,9 @@ export class VanillaKMTEventParser implements KMTEventParser {
 
     private _eventTarget: EventTargetWithPointerEvents;
 
-    constructor(eventTarget: EventTargetWithPointerEvents, stateMachine: KmtInputStateMachine){
+    constructor(eventTarget: EventTargetWithPointerEvents, observableInputTracker: ObservableInputTracker){
         this.bindFunctions();
-        this._stateMachine = stateMachine;
+        this._stateMachine = createKmtInputStateMachine(observableInputTracker);
         this._keyfirstPressed = new Map();
         this._eventTarget = eventTarget;
     }

--- a/src/touch-event-parser/vanilla-touch-event-parser.ts
+++ b/src/touch-event-parser/vanilla-touch-event-parser.ts
@@ -1,5 +1,4 @@
-import { RawUserInputPublisher } from "src/raw-input-publisher";
-import { TouchPoints, TouchInputStateMachine } from "src/input-state-machine/touch-input-state-machine";
+import { TouchPoints, TouchInputStateMachine, createTouchInputStateMachine } from "src/input-state-machine/touch-input-state-machine";
 import { TouchInputTracker } from "src/input-state-machine/touch-input-context";
 
 /**
@@ -13,7 +12,6 @@ export interface TouchEventParser {
     panDisabled: boolean;
     zoomDisabled: boolean;
     rotateDisabled: boolean;
-    touchStateMachine: TouchInputStateMachine;
     enableStrategy(): void;
     disableStrategy(): void;
     setUp(): void;
@@ -39,10 +37,10 @@ export class VanillaTouchEventParser implements TouchEventParser {
 
     private touchPointsMap: Map<number, TouchPoints> = new Map<number, TouchPoints>();
 
-    constructor(canvas: HTMLCanvasElement, stateMachine: TouchInputStateMachine){
+    constructor(canvas: HTMLCanvasElement, observableInputTracker: TouchInputTracker){
         this._canvas = canvas;
         this._disabled = false;
-        this.touchSM = stateMachine;
+        this.touchSM = createTouchInputStateMachine(observableInputTracker);
 
         this.bindListeners();
     }


### PR DESCRIPTION
Although event parser and input state machine are two separate classes, they should be seen as one from the outside. The input state machine depends on the events that are parsed by the event parser; the two cannot survive without one another.